### PR TITLE
Allow setting a custom backend storage

### DIFF
--- a/4/templates/varnishd.init.d.tpl
+++ b/4/templates/varnishd.init.d.tpl
@@ -6,14 +6,6 @@ if [[ -n "${DEBUG}" ]]; then
     set -x
 fi
 
-{{ $secondary_storage := false }}
-{{ if getenv "VARNISHD_SECONDARY_STORAGE" }}
-  {{ $secondary_storage := (getenv "VARNISHD_SECONDARY_STORAGE") }}
-{{ else if getenv "VARNISHD_STORAGE_SIZE" }}
-  {{ $secondary_storage := (printf "file,/var/lib/varnish/storage.bin,%s" (getenv "VARNISHD_STORAGE_SIZE")) }}
-{{ end }}
-  
-
 exec varnishd \
     -j unix,user=varnish \
     -F \
@@ -22,7 +14,7 @@ exec varnishd \
     -f {{ getenv "VARNISHD_VCL_SCRIPT" "/etc/varnish/default.vcl" }} \
     -S {{ getenv "VARNISHD_SECRET_FILE" "/etc/varnish/secret" }} \
     -s main=malloc,{{ getenv "VARNISHD_MEMORY_SIZE" "64M" }} \
-    {{ if $secondary_storage }} -s secondary={{ $secondary_storage }} {{ end }}\
+    {{ if getenv "VARNISHD_SECONDARY_STORAGE" }} -s secondary={{ getenv "VARNISHD_SECONDARY_STORAGE" }} {{ end }}\
     -t {{ getenv "VARNISHD_DEFAULT_TTL" "120" }} \
     -p ban_lurker_age={{ getenv "VARNISHD_PARAM_BAN_LURKER_AGE" "60.000" }} \
     -p ban_lurker_batch={{ getenv "VARNISHD_PARAM_BAN_LURKER_BATCH" "1000" }} \

--- a/4/templates/varnishd.init.d.tpl
+++ b/4/templates/varnishd.init.d.tpl
@@ -7,10 +7,10 @@ if [[ -n "${DEBUG}" ]]; then
 fi
 
 {{ $alternative_storage := false }}
-{{ if getenv "VARNISHD_STORAGE_SIZE" }}
-  {{ $alternative_storage := (printf "file,/var/lib/varnish/storage.bin,%s" (getenv "VARNISHD_STORAGE_SIZE")) }}
-{{ else if getenv "VARNISHD_SECONDARY_STORAGE" }}
+{{ if getenv "VARNISHD_SECONDARY_STORAGE" }}
   {{ $alternative_storage := (getenv "VARNISHD_SECONDARY_STORAGE") }}
+{{ else if getenv "VARNISHD_STORAGE_SIZE" }}
+  {{ $alternative_storage := (printf "file,/var/lib/varnish/storage.bin,%s" (getenv "VARNISHD_STORAGE_SIZE")) }}
 {{ end }}
   
 

--- a/4/templates/varnishd.init.d.tpl
+++ b/4/templates/varnishd.init.d.tpl
@@ -9,8 +9,8 @@ fi
 {{ $alternative_storage := false }}
 {{ if getenv "VARNISHD_STORAGE_SIZE" }}
   {{ $alternative_storage := (printf "file,/var/lib/varnish/storage.bin,%s" (getenv "VARNISHD_STORAGE_SIZE")) }}
-{{ else if getenv "VARNISHD_STORAGE_CUSTOM" }}
-  {{ $alternative_storage := (getenv "VARNISHD_STORAGE_CUSTOM") }}
+{{ else if getenv "VARNISHD_SECONDARY_STORAGE" }}
+  {{ $alternative_storage := (getenv "VARNISHD_SECONDARY_STORAGE") }}
 {{ end }}
   
 

--- a/4/templates/varnishd.init.d.tpl
+++ b/4/templates/varnishd.init.d.tpl
@@ -6,11 +6,11 @@ if [[ -n "${DEBUG}" ]]; then
     set -x
 fi
 
-{{ $alternative_storage := false }}
+{{ $secondary_storage := false }}
 {{ if getenv "VARNISHD_SECONDARY_STORAGE" }}
-  {{ $alternative_storage := (getenv "VARNISHD_SECONDARY_STORAGE") }}
+  {{ $secondary_storage := (getenv "VARNISHD_SECONDARY_STORAGE") }}
 {{ else if getenv "VARNISHD_STORAGE_SIZE" }}
-  {{ $alternative_storage := (printf "file,/var/lib/varnish/storage.bin,%s" (getenv "VARNISHD_STORAGE_SIZE")) }}
+  {{ $secondary_storage := (printf "file,/var/lib/varnish/storage.bin,%s" (getenv "VARNISHD_STORAGE_SIZE")) }}
 {{ end }}
   
 
@@ -22,7 +22,7 @@ exec varnishd \
     -f {{ getenv "VARNISHD_VCL_SCRIPT" "/etc/varnish/default.vcl" }} \
     -S {{ getenv "VARNISHD_SECRET_FILE" "/etc/varnish/secret" }} \
     -s main=malloc,{{ getenv "VARNISHD_MEMORY_SIZE" "64M" }} \
-    {{ if $alternative_storage }} -s secondary={{ $alternative_storage }} {{ end }}\
+    {{ if $secondary_storage }} -s secondary={{ $secondary_storage }} {{ end }}\
     -t {{ getenv "VARNISHD_DEFAULT_TTL" "120" }} \
     -p ban_lurker_age={{ getenv "VARNISHD_PARAM_BAN_LURKER_AGE" "60.000" }} \
     -p ban_lurker_batch={{ getenv "VARNISHD_PARAM_BAN_LURKER_BATCH" "1000" }} \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Supported tags and respective `Dockerfile` links:
 | `VARNISHD_PARAM_WORKSPACE_SESSION`         | `0.50k`                    |                                  |
 | `VARNISHD_PARAM_WORKSPACE_THREAD`          | `2k`                       |                                  |
 | `VARNISHD_SECRET_FILE`                     | `/etc/varnish/secret`      |                                  |
-| `VARNISHD_STORAGE_SIZE`                    |                            |                                  |
+| `VARNISHD_SECONDARY_STORAGE`               |                            |                                  |
 | `VARNISHD_VCL_SCRIPT`                      | `/etc/varnish/default.vcl` |                                  |
 
 ## Orchestration Actions


### PR DESCRIPTION
With this change the secondary storage bin can be customised on demand, allowing to define, for example, another memory storage.
This is  can be particularly useful in conjunction with wodby/drupal-varnish#3 because it allows the bin to be completely customised.

_Note_ This is an extension of `VARNISHD_STORAGE_SIZE`, making it more customisable while preserving backward compatibility.