### PR TITLE
Varnish: Adjust preset.vcl include order.

### DIFF
--- a/4/templates/default.vcl.tmpl
+++ b/4/templates/default.vcl.tmpl
@@ -12,14 +12,13 @@ sub vcl_recv {
     }
 }
 
+include "preset.vcl";
+
 include "includes/purge.vcl";
 include "includes/static.vcl";
 include "includes/mobile.vcl";
 
 include "defaults/vcl_recv.vcl";
-
-include "preset.vcl";
-
 include "defaults/vcl_hash.vcl";
 include "defaults/vcl_pipe.vcl";
 include "defaults/vcl_backend_response.vcl";


### PR DESCRIPTION
Firstly, thanks for the excellent work on this set of Docker images and related configuration!  Great stuff.

Anyway, I'd like to submit a patch to fix an issue that happens when using Varnish with Drupal private files (system/files)

Because `preset.vcl` is included after `static.vcl` in the default template, then the `vcl_recv` will strip the cookies from the private file request, e.g https://example.com/system/files/sample.csv

```
sub vcl_recv {
    if (req.url ~ "(?i)\.({{ $static_files }})(\?.*)?$") {
        unset req.http.Cookie;
```

The cookies are required to authenticate the private file download request for Drupal.

This patch simply adjusts the ordering, to allow the `preset.vcl` to override `static.vcl` in `vcl_recv` for the system/files path, to return the `pass` there

Please check sometime and apply if suitable, thanks again.