### PR TITLE
Detect country code against X-Real-IP header instead of X-Forwarded-For

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ On your backend you should check whether `VCKEY-` cookie exists, if it does gene
 
 We identify client's two-letter country code ([ISO 3166](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)) and pass it to a backend in `X-Country-Code` header. If Varnish could not recognize the country the default value will be `Unknown`. You can optionally uniquify cache per country by setting `$VARNISH_CACHE_PER_COUNTRY=1`. We use GeoLite database from MaxMind.
 
+
 If we see CloudFlare country code header we use it instead.
 
 ### Currency
@@ -237,7 +238,7 @@ AD|AT|BE|CY|EE|FI|FR|GF|TF|DE|GP|GR|VA|IE|IT|LV|LT|LU|MT|MQ|YT|MC|ME|NL|PT|RE|BL
 * Purge and ban requests both use Varnish's `ban` method to flush cache and restricted by the purge key `$VARNISH_PURGE_KEY` (generated if missing). Use header `X-VC-Purge-Key` to pass the key for purge/ban requests
 * Purge requests look up for exact match but ignores query params, you can change the method by setting `X-VC-Purge-Method` to `regex` or `exact` (respects query params)
 * Additionally for ban requests cache flushed by `Cache-Tags` header (Drupal's case)
-* if you want to allow unrestricted purge/ban requests in internal network specify a header via `$VARNISH_PURGE_EXTERNAL_REQUEST_HEADER` that exists only for external requests (e.g. `X-Real-IP`). If specified header is not set Varnish will skip purge key check
+* If you want to allow unrestricted purge/ban requests in internal network specify a header via `$VARNISH_PURGE_EXTERNAL_REQUEST_HEADER` that exists only for external requests (e.g. `X-Real-IP`). If specified header is not set Varnish will skip purge key check
 
 ### Miscellaneous
 

--- a/templates/default.vcl.tmpl
+++ b/templates/default.vcl.tmpl
@@ -13,8 +13,10 @@ import geoip;
 sub vcl_recv {
     if (req.http.CF-IPCountry) {
         set req.http.X-Country-Code = req.http.CF-IPCountry;
+    } elseif (req.http.X-Real-IP) {
+        set req.http.X-Country-Code = geoip.country_code(req.http.X-Real-IP);
     } else {
-        set req.http.X-Country-Code = geoip.country_code(regsub(req.http.X-Forwarded-For, ".*\b(?!10|127)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}).*", "\1"));
+        set req.http.X-Country-Code = geoip.country_code(client.ip);
     }
 
     if (req.http.X-Country-Code) {

--- a/tests/basic/run.sh
+++ b/tests/basic/run.sh
@@ -24,17 +24,23 @@ us_ip="185.229.59.42"
 
 echo -n "Checking varnish backend response containing a country code header detected via geoip module... "
 docker-compose exec php sh -c 'echo "<?php var_dump(\$_SERVER[\"HTTP_X_COUNTRY_CODE\"]);" > /var/www/html/index.php'
-varnish curl --header "X-Forwarded-For: ${us_ip}" -s "localhost:6081" | grep -q "US"
+varnish curl --header "X-Real-IP: ${us_ip}" -s "localhost:6081" | grep -q "US"
 varnish make flush -f /usr/local/bin/actions.mk
 echo "OK"
 
 echo -n "Checking varnish backend response containing the currency... "
 docker-compose exec php sh -c 'echo "<?php var_dump(\$_SERVER[\"HTTP_X_CURRENCY\"]);" > /var/www/html/index.php'
-varnish curl --header "X-Forwarded-For: ${us_ip}" -s "localhost:6081" | grep -q "USD"
+varnish curl --header "X-Real-IP: ${us_ip}" -s "localhost:6081" | grep -q "USD"
 varnish make flush -f /usr/local/bin/actions.mk
 echo "OK"
 
-echo -n "Checking varnish VC-KEY cookies... "
+echo -n "Checking varnish backend response containing the currency (from Cloudflare \"CF-IPCountry\" header)... "
+docker-compose exec php sh -c 'echo "<?php var_dump(\$_SERVER[\"HTTP_X_CURRENCY\"]);" > /var/www/html/index.php'
+varnish curl --header "CF-IPCountry: US" -s "localhost:6081" | grep -q "USD"
+varnish make flush -f /usr/local/bin/actions.mk
+echo "OK"
+
+echo -n "Checking varnish VCKEY cookies... "
 docker-compose exec php sh -c 'echo "<?php echo(\"Hello World\");" > /var/www/html/index.php'
 varnish sh -c 'curl -sI -b "VCKEYinvalid=123"  localhost:6081 | grep -q "X-VC-Cache: MISS"'
 varnish sh -c 'curl -sI -b "VCKEYinvalid=123"  localhost:6081 | grep -q "X-VC-Cache: MISS"'


### PR DESCRIPTION
Detection of country code doesn't work if more than 2 IPs in `X-Forwarded-For`. Also, we should know a list of trusted proxies to securely detect real client's IP from `X-Forwarded-For`. The simpler way is to use `X-Real-IP` header that always a single IP value and provided either by Traefik and in cloud.