### PR TITLE
Added strict wp-admin rule for wordpress preset

### DIFF
--- a/templates/presets/wordpress.vcl.tmpl
+++ b/templates/presets/wordpress.vcl.tmpl
@@ -7,7 +7,8 @@ sub vcl_recv {
     {{ else }}
     # pass wp-admin urls
 	if (req.url ~ "(wp-login|wp-admin)" || req.url ~ "preview=true" || req.url ~ "xmlrpc.php") {
-		return (pass);
+	    set req.http.X-VC-Cacheable = "NO:Admin domain";
+	    return (pass);
 	}
     {{ end }}
 

--- a/templates/presets/wordpress.vcl.tmpl
+++ b/templates/presets/wordpress.vcl.tmpl
@@ -4,6 +4,11 @@ sub vcl_recv {
         set req.http.X-VC-Cacheable = "NO:Admin domain";
         return(pass);
     }
+    {{ else }}
+    # pass wp-admin urls
+	if (req.url ~ "(wp-login|wp-admin)" || req.url ~ "preview=true" || req.url ~ "xmlrpc.php") {
+		return (pass);
+	}
     {{ end }}
 
     # Pass through some requests that are specifically for the WordPress Jetpack mobile plugin.

--- a/templates/presets/wordpress.vcl.tmpl
+++ b/templates/presets/wordpress.vcl.tmpl
@@ -7,7 +7,7 @@ sub vcl_recv {
     {{ else }}
     # pass wp-admin urls
 	if (req.url ~ "(wp-login|wp-admin)" || req.url ~ "preview=true" || req.url ~ "xmlrpc.php") {
-	    set req.http.X-VC-Cacheable = "NO:Admin domain";
+	    set req.http.X-VC-Cacheable = "NO:Admin";
 	    return (pass);
 	}
     {{ end }}


### PR DESCRIPTION
I found an issue with wp-admin redirect looping with Duo 2FA enabled. This seemed to have fixed the issue.